### PR TITLE
combine add file and data in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,13 @@ Triggered when it updates, ie something added/removed an entry
 
 Get an entry.
 
-#### `value = await pass.getFile(name)`
-
-Get a file.
-
 #### `stream = pass.list()`
 
 Get all entries.
 
-#### `await pass.add(key, value)`
+#### `await pass.add(key, value, file)`
 
 Add new entry
-
-#### `await pass.addFile(name, buffer)`
-
-Add new file
 
 #### `await pass.remove(key)`
 

--- a/index.js
+++ b/index.js
@@ -293,20 +293,8 @@ class Autopass extends ReadyResource {
     this.swarm.join(this.base.discoveryKey)
   }
 
-  async add(key, value) {
-    await this.base.append(dispatch('@autopass/put', { key, value }))
-  }
-
-  async addFile(key, file) {
-    await this.base.append(dispatch('@autopass/put', { key, file }))
-  }
-
-  async getFile(key) {
-    const data = await this.base.view.get('@autopass/records', { key })
-    if (data === null) {
-      return null
-    }
-    return data.file
+  async add(key, value, file) {
+    await this.base.append(dispatch('@autopass/put', { key, value, file }))
   }
 
   async remove(key) {


### PR DESCRIPTION
Previous:
pass.add(key,value)
pass.addFile(key,file)

Now:
pass.add(key,value,file)

Reason:
#1 does not make sense because the key for file will overwrite the previous record.